### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/pardinn/PlayWrightAutomation/security/code-scanning/1](https://github.com/pardinn/PlayWrightAutomation/security/code-scanning/1)

To fix the problem, explicitly add a `permissions` block with minimally required permissions for the workflow. Since the workflow does not push code, make releases, or modify issues or pull-requests, specifying `contents: read` at the job level (within the `test` job) or the global workflow level is sufficient. The fix should be made by inserting the following lines after `name: Playwright Tests` and before `on:` (if setting globally), or after `test:` and before any job properties (if setting per job). For maintainability and least privilege, it’s correctly recommended to add it globally to apply to all jobs. No additional methods or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
